### PR TITLE
Request for clarification: Owner TypeCode values in handbook vs XSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,21 @@ The specific type of data to be contained between defined tags can be specified
 in the XSD file referenced above.  This makes it possible to ensure that data 
 transmitted by XML is of the correct data type, thereby making it easier for 
 the recipient to import the transmitted data to a database or application.
+
+## Clarification Request
+
+While implementing NAUPA III v1.4 XML reporting, I noticed a possible discrepancy between the handbook and Remittance.xsd regarding Owner TypeCode values.
+
+Handbook values appear to include:
+- IND (Individual Owner)
+- BUS (Business Owner)
+- UNK (Unknown Owner)
+- AGG (Aggregate Owner)
+
+Remittance.xsd currently restricts Owner TypeCode to:
+- NamedOwner
+- Unknown
+- Aggregate
+
+Could the maintainers please clarify which values should be used for NAUPA III v1.4 reporting?
+No functional changes are being proposed. This request is intended solely to obtain clarification because Issues are unavailable for this repository.


### PR DESCRIPTION
Hello,

While implementing NAUPA III v1.4 XML reporting, I noticed what appears to be a discrepancy between the handbook and Remittance.xsd v1.4.

The handbook appears to define Owner TypeCode values as:

IND = Individual Owner
BUS = Business Owner
UNK = Unknown Owner
AGG = Aggregate Owner

However, the current Remittance.xsd restricts Owner TypeCode to:

NamedOwner
Unknown
Aggregate

As a result, XML generated according to the handbook fails XSD validation.

Could the maintainers please clarify which values are intended for NAUPA III v1.4 reporting?

No functional schema changes are being proposed. This pull request is intended solely to request clarification because Issues are currently unavailable for the repository.

Thank you,

Jesse Contreras Jr.
